### PR TITLE
Fix a couple of C compiler warnings.

### DIFF
--- a/applydeltarpm.c
+++ b/applydeltarpm.c
@@ -1575,7 +1575,7 @@ main(int argc, char **argv)
 	  exit(1);
 	}
       rpmMD5Update(&wrmd5, d.h->intro, 16);
-      strncpy((char *)d.h->dp + d.payformatoff, "cpio", 4);
+      memcpy((char *)d.h->dp + d.payformatoff, "cpio", 4);
       if (fwrite(d.h->data, 16 * d.h->cnt + d.h->dcnt, 1, ofp) != 1)
 	{
 	  fprintf(stderr, "write error\n");

--- a/deltarpmmodule.c
+++ b/deltarpmmodule.c
@@ -45,7 +45,7 @@ PyObject *createDict(struct deltarpm d)
   /* Sequence */
   if (d.seq) {
     char *tmp = calloc(d.seql * 2 + 1, sizeof(char));
-    int i;
+    unsigned int i;
 
     if(tmp == NULL) {
       PyErr_SetFromErrno(PyExc_SystemError);

--- a/md5.c
+++ b/md5.c
@@ -161,7 +161,7 @@ void rpmMD5Final(unsigned char digest[16], struct MD5Context *ctx)
     if (ctx->doByteReverse)
 	byteReverse((unsigned char *) ctx->buf, 4);
     memcpy(digest, ctx->buf, 16);
-    memset(ctx, 0, sizeof(ctx));	/* In case it's sensitive */
+    memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
 }
 
 /* The four core functions - F1 is optimized somewhat */


### PR DESCRIPTION
Hi,

Thanks for working on deltarpm!

What do you think about the attached patch that fixes a couple of GCC warning messages? I recently applied it to the Debian package of deltarpm; you may also view it at https://salsa.debian.org/pkg-rpm-team/deltarpm/-/blob/debian/master/debian/patches/warnings.patch

G'luck,
Peter
