### PR TITLE
Correct a couple of typographical and grammatical errors.

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ A) Programs
 
     Options:
       -V: create a specific version, default is V3
-      -s: write sequence info into file (usefull for creating
+      -s: write sequence info into file (useful for creating
 	  yast patchfiles)
 
     applydeltarpm [-v] [-p] [-c] [-C] [-r oldrpm] deltarpm newrpm
@@ -96,7 +96,7 @@ standard deltarpms:
     4 bytes seqlength (always 16 if header included in diff)
     x bytes sequence, containing
             16 bytes seq md5sum
-            x bytes compressed seqence
+            x bytes compressed sequence
             (the sequence defines which files get included from the rpm
              filelist in which order)
                

--- a/applydeltarpm.8
+++ b/applydeltarpm.8
@@ -39,8 +39,8 @@ to make applydeltarpm print the percentage of completion, or
 .B -v
 to make it more verbose about its operation.
 
-The second an third form can be used to check if the reconstruction
-is possible. It may fail if the on-disk data got changed
+The second and third form can be used to check if the reconstruction
+is possible. It may fail if the on-disk data was changed
 (deltarpms are created in a way that config file changes do not
 matter) or the deltarpm does not match the rpm the delta was generated
 with. The

--- a/applydeltarpm.c
+++ b/applydeltarpm.c
@@ -848,7 +848,7 @@ fillblock_rpm(struct blk *b, int id, struct seqdescr *sdesc, int nsdesc, struct 
 }
 
 
-/* construct the block "id". Note that the tupel (idx, id) will
+/* construct the block "id". Note that the tuple (idx, id) will
  * only get bigger, so we use this to recycly no longer needed
  * blocks */
 

--- a/combinedeltarpm.8
+++ b/combinedeltarpm.8
@@ -36,8 +36,8 @@ If you want to use a different header
 signature you can also specify a rpm with the
 .B -S
 option which will be used as signature reference. This feature can
-be used to if a deltarpm was made against an unsigned rpm which
-later got signed.
+be used to if a deltarpm was made against an unsigned rpm which was
+later signed.
 
 .SH MEMORY CONSIDERATIONS
 The implementation of combinedeltarpm currently unpacks the

--- a/drpmsync
+++ b/drpmsync
@@ -2486,7 +2486,7 @@ sub rsync_get_syncfiles {
     last if $buf eq "\@RSYNCD: OK";
     die("$buf\n") if $buf =~ /^\@ERROR/s;
     if ($buf =~ /^\@RSYNCD: AUTHREQD /) {
-      die("'$module' needs authentification, but Digest::MD4 is not installed\n") unless $have_md4;
+      die("'$module' needs authentication, but Digest::MD4 is not installed\n") unless $have_md4;
       $user = "nobody" if !defined($user) || $user eq '';
       $password = '' unless defined $password;
       my $digest = "$user ".Digest::MD4::md4_base64("\0\0\0\0$password".substr($buf, 18))."\n";

--- a/drpmsync.8
+++ b/drpmsync.8
@@ -105,7 +105,7 @@ update from.
 Configures whether drpmsync should request that the full rpm is
 always sent along with the delta. Only makes sense if you have a
 fast network connection so that applydeltarpm takes longer than
-transmitting the ful rpm.
+transmitting the full rpm.
 .sp
 .ne 3
 .B deltarpmpath:
@@ -117,7 +117,7 @@ The default is to search the
 variable.
 
 .SH SERVER MODE
-Drpmsync can wither work as CGI script or as a standalone server.
+Drpmsync can either work as CGI script or as a standalone server.
 CGI script mode is automatically selected if the
 .B REQUEST_METHOD
 environment variable is set. In this mode drpmsync expects the
@@ -179,7 +179,7 @@ Specifies the path of a logfile.
 .BR true|false
 .PP
 If this setting is true the server does not combine deltarpms.
-This increases to amount of data that has to be transferred but
+This increases the amount of data that has to be transferred but
 reduces the processor load on the server.
 .sp
 .ne 3

--- a/makedeltarpm.8
+++ b/makedeltarpm.8
@@ -73,7 +73,7 @@ option to specify the rpm-print of
 .I oldrpm
 and the created
 patch rpm. This option tells makedeltarpm to exclude the files that
-were not included in the patch rpm but are not byteswise identical
+were not included in the patch rpm but are not bytewise identical
 to the ones in oldrpm.
 .PP
 makedeltarpm can also create an "identity" deltarpm by adding the
@@ -88,7 +88,7 @@ of the rpm's uncompressed payload. You can use the
 .B -m
 option to enable a sliding block algorithm that needs
 .IR mbytes
-megabytes of memory. This trades memory usage with the size of
+megabytes of memory. This trades memory usage for the size of
 the created deltarpm. Furthermore, the uncompressed deltarpm
 payload is currently also stored in memory when this option is
 used, but it tends to be small in most cases.

--- a/makedeltarpm.c
+++ b/makedeltarpm.c
@@ -1233,7 +1233,7 @@ main(int argc, char **argv)
 	      if (size != filesizes[i])
 		{
 		  if (verbose > 1)
-		    fprintf(vfp, "skipping %s: size missmatch\n", np);
+		    fprintf(vfp, "skipping %s: size mismatch\n", np);
 		  skipped_badsize++;
 		}
 	      else if ((fileflags[i] & (FILE_CONFIG|FILE_MISSINGOK|FILE_GHOST)) != 0)


### PR DESCRIPTION
Hi,

Thanks for working on deltarpm!

What do you think about this trivial change - a couple of typographical and grammatical fixes for user-visible messages and documentation? I recently applied it to the Debian package of deltarpm; you may also view it at https://salsa.debian.org/pkg-rpm-team/deltarpm/-/blob/debian/master/debian/patches/typos.patch

G'luck,
Peter
