### PR TITLE
Honor CPPFLAGS when building the Python module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ _deltarpmmodule.so: readdeltarpm.o rpmhead.o util.o md5.o cfile.o $(zlibbundled)
 			PYCFLAGS=`$$PY-config --cflags`; \
 			if [ ! -f "python$$PYVER/$@" ]; then \
 				mkdir -p python$$PYVER ;\
-				$(CC) $(CFLAGS) $$PYCFLAGS $(zlibcppflags) -fPIC -c -o python$$PYVER/deltarpmmodule.o deltarpmmodule.c ;\
+				$(CC) $(CPPFLAGS) $(CFLAGS) $$PYCFLAGS $(zlibcppflags) -fPIC -c -o python$$PYVER/deltarpmmodule.o deltarpmmodule.c ;\
 				$(CC) $(LDFLAGS) -o python$$PYVER/$@ python$$PYVER/deltarpmmodule.o $^ -shared -Wl,-soname,_deltarpmmodule.so $(LDLIBS); \
 			fi; \
 		fi; \


### PR DESCRIPTION
Hi,

First of all, thanks for your continued work on deltarpm!

What do you think about this trivial change that makes sure that the build of the Python module honors not only any environment or configured values for CFLAGS and LDFLAGS, but also CPPFLAGS?

Thanks in advance, and keep up the great work!

G'luck,
Peter
